### PR TITLE
Add enemy loop replay system

### DIFF
--- a/game_jam_game/scenes/game.tscn
+++ b/game_jam_game/scenes/game.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=10 format=4 uid="uid://cwbv2y4y74b4t"]
+[gd_scene load_steps=11 format=4 uid="uid://cwbv2y4y74b4t"]
 
 [ext_resource type="Texture2D" uid="uid://dpb0kysm7pg57" path="res://assets/sprites/grid.jpg" id="4_lbhrr"]
 [ext_resource type="Texture2D" uid="uid://q44iosxd057y" path="res://assets/sprites/world_tileset.png" id="5_iywne"]
@@ -6,6 +6,7 @@
 [ext_resource type="PackedScene" uid="uid://dvvyxv8mj7fho" path="res://scenes/player_manager.tscn" id="7_u5sy4"]
 [ext_resource type="Script" uid="uid://dkrqctvyafve4" path="res://scripts/damage_particle_manager.gd" id="8_damage_particle_manager"]
 [ext_resource type="PackedScene" uid="uid://dmn11pyh7fi6f" path="res://scenes/enemy.tscn" id="9_0tnpc"]
+[ext_resource type="Script" uid="uid://dts9hkqk4b4y5" path="res://scripts/enemy_manager.gd" id="10_enemy_manager"]
 
 [sub_resource type="WorldBoundaryShape2D" id="WorldBoundaryShape2D_e2o6t"]
 distance = 256.0
@@ -177,3 +178,5 @@ tile_map_data = PackedByteArray("AAD9/wAAAQAAAAAAAAD+/wAAAQAAAAAAAAD//wAAAQAAAAA
 tile_set = SubResource("TileSet_u5sy4")
 
 [node name="PlayerManager" parent="Level" instance=ExtResource("7_u5sy4")]
+[node name="EnemyManager" type="Node" parent="Level"]
+script = ExtResource("10_enemy_manager")

--- a/game_jam_game/scripts/enemy.gd
+++ b/game_jam_game/scripts/enemy.gd
@@ -3,6 +3,12 @@ extends CharacterBody2D
 @onready var animation_player := $AnimationPlayer
 @onready var sprite := $Sprite2D
 
+# -- Loop recording system -- #
+@onready var state_buffer: RingBuffer = RingBuffer.create_by_seconds(15, Engine.get_physics_ticks_per_second())
+var is_replaying: bool = false
+var replay_index: int = 0
+var is_dead: bool = false
+
 # Physics variables (matching player physics system)
 var gravity: float = ProjectSettings.get_setting("physics/2d/default_gravity")  # Base gravity from project settings
 @export var fall_gravity_scale: float = 20.0  # Same as player's fall state
@@ -132,10 +138,10 @@ class ActionNode extends DecisionTreeNode:
 var decision_tree: DecisionTreeNode
 
 func _ready():
-	# Add the enemy to a group so other systems can find it
-	add_to_group("enemies")
-	current_health = max_health
-	patrol_start_position = global_position
+        # Add the enemy to a group so other systems can find it
+        add_to_group("enemies")
+        current_health = max_health
+        patrol_start_position = global_position
 	
 	# Scale down the enemy to fit better on platforms
 	scale = Vector2(0.8, 0.8)  # Make enemy 80% of original size
@@ -175,12 +181,33 @@ func _ready():
 	print("Enemy is_on_floor(): ", is_on_floor())
 	print("Enemy patrol start position: ", patrol_start_position)
 	
-	# Build the decision tree
-	_build_decision_tree()
+        # Build the decision tree
+        _build_decision_tree()
+
+        # Register with enemy manager after scene is ready
+        call_deferred("_register_with_manager")
+
+func _register_with_manager() -> void:
+        var manager = get_tree().get_first_node_in_group("enemy_manager")
+        if manager:
+                manager.register_enemy(self)
 
 func reset_to_spawn() -> void:
-		global_position = patrol_start_position
-		velocity = Vector2.ZERO
+                global_position = patrol_start_position
+                velocity = Vector2.ZERO
+
+func reset_for_new_loop() -> void:
+        reset_to_spawn()
+        is_dead = false
+        visible = true
+        if has_node("CollisionShape2D"):
+                $CollisionShape2D.disabled = false
+        if has_node("HurtBox/CollisionShape2D"):
+                $HurtBox/CollisionShape2D.disabled = false
+        if has_node("BodyHitBox/CollisionShape2D"):
+                $BodyHitBox/CollisionShape2D.disabled = false
+        is_replaying = true
+        replay_index = 0
 
 # Recursive function to find player
 func _find_player_recursive(node: Node) -> CharacterBody2D:
@@ -433,12 +460,31 @@ func set_passive_body_damage_enabled(enabled: bool):
 			print("Enemy passive body damage ", "enabled" if enabled else "disabled")
 
 func _physics_process(delta):
-	# Update spawn invincibility timer
-	if is_spawn_invincible:
-		spawn_invincibility_timer -= delta
-		if spawn_invincibility_timer <= 0.0:
-			is_spawn_invincible = false
-			print("Enemy spawn invincibility ended")
+        if is_replaying:
+                if state_buffer.length == 0:
+                        return
+                var tick = state_buffer.get_at(replay_index)
+                global_position = tick.position
+                velocity = tick.velocity
+                visible = tick.alive
+                is_dead = not tick.alive
+                replay_index = (replay_index + 1) % state_buffer.length
+                return
+
+        if is_dead:
+                state_buffer.push({
+                        "position": global_position,
+                        "velocity": velocity,
+                        "alive": false
+                })
+                return
+
+        # Update spawn invincibility timer
+        if is_spawn_invincible:
+                spawn_invincibility_timer -= delta
+                if spawn_invincibility_timer <= 0.0:
+                        is_spawn_invincible = false
+                        print("Enemy spawn invincibility ended")
 	
 	# Update attack timer
 	if attack_timer > 0:
@@ -545,12 +591,18 @@ func _physics_process(delta):
 	move_and_slide()
 	
 	# Additional safety check: if enemy is still overlapping significantly, move it out
-	if get_slide_collision_count() > 0:
-		for i in get_slide_collision_count():
-			var collision = get_slide_collision(i)
-			if collision and collision.get_travel().length() > max_horizontal_penetration:
-				# Force push away from collision
-				global_position += collision.get_normal() * collision_safety_margin
+        if get_slide_collision_count() > 0:
+                for i in get_slide_collision_count():
+                        var collision = get_slide_collision(i)
+                        if collision and collision.get_travel().length() > max_horizontal_penetration:
+                                # Force push away from collision
+                                global_position += collision.get_normal() * collision_safety_margin
+
+        state_buffer.push({
+                "position": global_position,
+                "velocity": velocity,
+                "alive": true
+        })
 
 # AI Behavior System (Decision Tree Based)
 func update_ai_behavior(delta: float):
@@ -1069,9 +1121,18 @@ func take_damage(damage_amount: int) -> void:
 		die()
 
 func die():
-	print("Enemy defeated!")
-	# You can add death effects here (particles, sound, etc.)
-	queue_free()
+        if is_dead:
+                return
+        print("Enemy defeated!")
+        # You can add death effects here (particles, sound, etc.)
+        is_dead = true
+        visible = false
+        if has_node("CollisionShape2D"):
+                $CollisionShape2D.disabled = true
+        if has_node("HurtBox/CollisionShape2D"):
+                $HurtBox/CollisionShape2D.disabled = true
+        if has_node("BodyHitBox/CollisionShape2D"):
+                $BodyHitBox/CollisionShape2D.disabled = true
 
 # Apply knockback when hit
 func apply_knockback(knockback_vector: Vector2):

--- a/game_jam_game/scripts/enemy_manager.gd
+++ b/game_jam_game/scripts/enemy_manager.gd
@@ -1,0 +1,22 @@
+extends Node
+class_name EnemyManager
+
+var enemies: Array[Node] = []
+
+func _ready() -> void:
+        add_to_group("enemy_manager")
+        _refresh_enemy_list()
+
+func _refresh_enemy_list() -> void:
+        enemies.clear()
+        for e in get_tree().get_nodes_in_group("enemies"):
+                enemies.append(e)
+
+func register_enemy(enemy: Node) -> void:
+        if enemy not in enemies:
+                enemies.append(enemy)
+
+func reset_enemies() -> void:
+        for e in enemies:
+                if e and e.has_method("reset_for_new_loop"):
+                        e.reset_for_new_loop()

--- a/game_jam_game/scripts/enemy_manager.gd.uid
+++ b/game_jam_game/scripts/enemy_manager.gd.uid
@@ -1,0 +1,1 @@
+uid://dts9hkqk4b4y5

--- a/game_jam_game/scripts/player_manager.gd
+++ b/game_jam_game/scripts/player_manager.gd
@@ -79,13 +79,17 @@ func _unhandled_input(event: InputEvent) -> void:
 
 # Called when a track's ring buffer becomes full and starts replaying
 func _on_loop_started(looping_track_idx: int) -> void:
-	# Only switch if it's from the active track
-	if looping_track_idx != active_track_idx:
-		return
-	# Compute next track index (wraps around)
-		var next_idx = (active_track_idx + 1) % tracks.size()
-		# Switch control to the next track while keeping previous tracks visible
-		activate_track(next_idx)
+        # Only switch if it's from the active track
+        if looping_track_idx != active_track_idx:
+                return
+        # Compute next track index (wraps around)
+                var next_idx = (active_track_idx + 1) % tracks.size()
+                # Switch control to the next track while keeping previous tracks visible
+                activate_track(next_idx)
+
+                var em = get_tree().get_first_node_in_group("enemy_manager")
+                if em:
+                        em.reset_enemies()
 
 # 
 # Enable input on the chosen track, disable on the others


### PR DESCRIPTION
## Summary
- record enemy state each tick and replay on subsequent loops
- manage enemy respawns via new EnemyManager
- trigger enemy resets when switching player tracks

## Testing
- `godot --headless --version` *(fails: command not found)*
- `gdlint --version` *(fails: command not found)*
- `gdformat --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892d02982a8832aafeae41726c6eadb