### PR TITLE
Sync cassette UI speed modifier label with time scale

### DIFF
--- a/game_jam_game/scripts/cassette_buttonless_ui.gd
+++ b/game_jam_game/scripts/cassette_buttonless_ui.gd
@@ -11,6 +11,7 @@ extends Control
 # UI References
 @onready var timer_label: Label = $TimerContainer/VBoxContainer/TimerLabel
 @onready var timer_progress_bar: ProgressBar = $ProgressBar
+@onready var speed_modifier_label: Label = $SpeedModifierContainer/SpeedModifierLabel
 
 # Hearts References
 @onready var hearts_container: HBoxContainer = $HeartsContainer
@@ -135,8 +136,11 @@ func get_max_health() -> int:
 	return max_health
 
 func is_alive() -> bool:
-		"""Check if player is still alive"""
-		return health_per_track.get(current_track, max_health) > 0
+                """Check if player is still alive"""
+                return health_per_track.get(current_track, max_health) > 0
+
+func update_speed_modifier_label() -> void:
+        speed_modifier_label.text = "%0.1fx" % Engine.time_scale
 
 func _ready():
 	# Store original positions for animation
@@ -193,8 +197,9 @@ func _ready():
 	current_track = 0
 	switch_to_track(1)
 	
-	# Drop red button by default when game starts
-	_drop_red_button()
+        # Drop red button by default when game starts
+        _drop_red_button()
+        update_speed_modifier_label()
 
 func _store_button_positions():
 	button_original_positions.clear()

--- a/game_jam_game/scripts/player_manager.gd
+++ b/game_jam_game/scripts/player_manager.gd
@@ -65,16 +65,20 @@ func _ready() -> void:
 
 func _unhandled_input(event: InputEvent) -> void:
 	# Speed up/slow down tick rate with C and Z (Godot 4.x compatible)
-	if event is InputEventKey and event.pressed and not event.echo:
-		if event.keycode == KEY_Z:
-			Engine.time_scale = max(0.1, Engine.time_scale - 0.5)
-			print("[PlayerManager] Slowed time_scale to ", Engine.time_scale)
-		elif event.keycode == KEY_C:
-			Engine.time_scale = Engine.time_scale + 0.5
-			print("[PlayerManager] Sped up time_scale to ", Engine.time_scale)
-	# Forward input to active track
-	if active_track_idx >= 0 and active_track_idx < tracks.size():
-		tracks[active_track_idx]._unhandled_input(event)
+        if event is InputEventKey and event.pressed and not event.echo:
+                if event.keycode == KEY_Z:
+                        Engine.time_scale = max(0.1, Engine.time_scale - 0.5)
+                        print("[PlayerManager] Slowed time_scale to ", Engine.time_scale)
+                        if cassette_ui:
+                                cassette_ui.update_speed_modifier_label()
+                elif event.keycode == KEY_C:
+                        Engine.time_scale = Engine.time_scale + 0.5
+                        print("[PlayerManager] Sped up time_scale to ", Engine.time_scale)
+                        if cassette_ui:
+                                cassette_ui.update_speed_modifier_label()
+        # Forward input to active track
+        if active_track_idx >= 0 and active_track_idx < tracks.size():
+                tracks[active_track_idx]._unhandled_input(event)
 
 
 # Called when a track's ring buffer becomes full and starts replaying
@@ -90,13 +94,17 @@ func _on_loop_started(looping_track_idx: int) -> void:
 # 
 # Enable input on the chosen track, disable on the others
 func activate_track(idx: int) -> void:
-	# Check if we're already on this track to prevent unnecessary work
-	if active_track_idx == idx:
-		return
+        # Check if we're already on this track to prevent unnecessary work
+        if active_track_idx == idx:
+                return
 
-	# Move the new active player to the spawn point
-	if idx >= 0 and idx < tracks.size():
-		tracks[idx].global_position = spawn_point
+        Engine.time_scale = 1.0
+        if cassette_ui:
+                cassette_ui.update_speed_modifier_label()
+
+        # Move the new active player to the spawn point
+        if idx >= 0 and idx < tracks.size():
+                tracks[idx].global_position = spawn_point
 
 	for i in range(tracks.size()):
 		var is_active := i == idx


### PR DESCRIPTION
## Summary
- expose SpeedModifierLabel to cassette UI and provide helper to display Engine.time_scale
- refresh label whenever PlayerManager adjusts Engine.time_scale or activates a new track
- reset Engine.time_scale to 1.0 when switching tracks

## Testing
- `godot --version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6892d1f2c6b0832a9a61a758b3d15547